### PR TITLE
Setup Unfavorite Property Feature

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -204,6 +204,34 @@ class User {
       [user.id, zpid]
     );
   }
+
+  /** Unfavorite a property.
+   *
+   * - username: user logged in
+   * - zpid: property id
+   *
+   * Returns undefined.
+   */
+
+  static async unFavoriteProperty(username, zpid) {
+    const userRes = await db.query(
+      `SELECT id,
+              username
+       FROM users
+       WHERE username = $1`,
+      [username]
+    );
+    const user = userRes.rows[0];
+
+    if (!user) throw new NotFoundError(`No username: ${username}`);
+
+    await db.query(
+      `DELETE FROM favorited_properties
+       WHERE user_id = $1
+       AND property_zpid = $2`,
+      [user.id, zpid]
+    );
+  }
 }
 
 module.exports = User;

--- a/models/user.test.js
+++ b/models/user.test.js
@@ -1,3 +1,4 @@
+process.env.NODE_ENV = "test";
 const bcrypt = require("bcrypt");
 
 const {
@@ -238,6 +239,41 @@ describe("favoriteProperty", function () {
   test("not found if no such user", async function () {
     try {
       await User.favoriteProperty("nope", testZpids[0]);
+      fail();
+    } catch (err) {
+      expect(err instanceof NotFoundError).toBeTruthy();
+    }
+  });
+});
+
+/************************************** unFavoriteProperty */
+
+describe("unFavoriteProperty", function () {
+  test("works", async function () {
+    await User.favoriteProperty("testuser", testZpids[1]);
+
+    const firstRes = await db.query(
+      'SELECT property_zpid AS "propertyZpid" FROM favorited_properties WHERE property_zpid=$1',
+      [testZpids[1]]
+    );
+    expect(firstRes.rows).toEqual([
+      {
+        propertyZpid: testZpids[1],
+      },
+    ]);
+
+    await User.unFavoriteProperty("testuser", testZpids[1]);
+
+    const secondRes = await db.query(
+      'SELECT property_zpid AS "propertyZpid" FROM favorited_properties WHERE property_zpid=$1 AND user_id=$2',
+      [testZpids[1], testUserIds[0]]
+    );
+    expect(secondRes.rows.length).toEqual(0);
+  });
+
+  test("not found if no such user", async function () {
+    try {
+      await User.unFavoriteProperty("nope", testZpids[0]);
       fail();
     } catch (err) {
       expect(err instanceof NotFoundError).toBeTruthy();

--- a/routes/users.js
+++ b/routes/users.js
@@ -66,7 +66,7 @@ router.delete("/:username", ensureCorrectUser, async function (req, res, next) {
   }
 });
 
-/** POST /[username]/[propertyZpid]  { state } => { application }
+/** POST /[username]/[propertyZpid]  { state } => { favorited }
  *
  * Returns { "favorited": propertyZpid }
  *
@@ -81,6 +81,25 @@ router.post(
       const propertyZpid = +req.params.propertyZpid;
       await User.favoriteProperty(req.params.username, propertyZpid);
       return res.json({ favorited: propertyZpid });
+    } catch (err) {
+      return next(err);
+    }
+  }
+);
+
+/** DELETE /[username]/[propertyZpid]  =>  { unFavorited: propertyZpid }
+ *
+ * Authorization required: admin or same-user-as-:username
+ * */
+
+router.delete(
+  "/:username/:propertyZpid",
+  ensureCorrectUser,
+  async function (req, res, next) {
+    try {
+      const propertyZpid = +req.params.propertyZpid;
+      await User.unFavoriteProperty(req.params.username, propertyZpid);
+      return res.json({ unFavorited: propertyZpid });
     } catch (err) {
       return next(err);
     }

--- a/routes/users.test.js
+++ b/routes/users.test.js
@@ -198,3 +198,37 @@ describe("POST /users/:username/:propertyZpid", function () {
     expect(resp.statusCode).toEqual(500);
   });
 });
+
+/************************************** DELETE /users/:username/:propertyZpid */
+
+describe("DELETE /users/:username/:propertyZpid", function () {
+  test("works for same user", async function () {
+    const resp = await request(app)
+      .delete(`/users/testuser/${testZpids[0]}`)
+      .set("authorization", `Bearer ${userToken}`);
+    expect(resp.body).toEqual({ unFavorited: testZpids[0] });
+  });
+
+  test("unauth for others", async function () {
+    const resp = await request(app)
+      .delete(`/users/testuser/${testZpids[0]}`)
+      .set("authorization", `Bearer ${user2Token}`);
+    expect(resp.statusCode).toEqual(401);
+  });
+
+  test("unauth for anon", async function () {
+    const resp = await request(app).delete(`/users/testuser/${testZpids[0]}`);
+    expect(resp.statusCode).toEqual(401);
+  });
+
+  test("fails: test next() handler", async function () {
+    // there's no normal failure event which will cause this route to fail ---
+    // thus making it hard to test that the error-handler works with it. This
+    // should cause an error, all right :)
+    await db.query("DROP TABLE users CASCADE");
+    const resp = await request(app)
+      .delete(`/users/testuser/${testZpids[0]}`)
+      .set("authorization", `Bearer ${userToken}`);
+    expect(resp.statusCode).toEqual(500);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
- This PR add the functionality for users to unfavorite a property.
- This PR closes #28 
### Description of Task to be completed
- Users should be able to unfavorite properties.
### How should this be manually tested?
- Send a delete request to `/users/:username/:property_zpid` and verify it is deleted from the favorited_properties table in database.